### PR TITLE
added link to alternative in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ from other languages).
 * Linkedin's [Flashback](https://github.com/linkedin/flashback) (since 2017)
 * Specto Lab's [Hoverfly](https://hoverfly.io/) (since 2015)
 * Computer Associate's [Lisa](https://www.ca.com/gb/products/ca-service-virtualization.html) since 2014 - unsure what tool name is now
+* [Karate](https://github.com/intuit/karate/tree/master/karate-netty) (since 2017)
 
 ## Code of Conduct
 


### PR DESCRIPTION
Thanks for this project, the record + markdown approach is interesting !

I thought that Karate can be included in the list of API test-double alternatives. It also does support [consumer-driven-contracts](https://hackernoon.com/api-consumer-contract-tests-and-test-doubles-with-karate-72c30ea25c18).

Thanks for your time !